### PR TITLE
Fix meta-driver build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM postgres:9.6
 RUN apt-get -y --quiet update \
       && apt-get -y --quiet install curl wget pkg-config \
                                     git-core make automake autoconf libtool gcc \
-                                    postgresql-server-dev-9.6 mongodb-dev
+                                    postgresql-server-dev-9.6 mongodb-dev libssl-dev
 RUN git clone --recursive https://github.com/EnterpriseDB/mongo_fdw.git /tmp/fdw
 
 RUN cd /tmp/fdw \


### PR DESCRIPTION
It failed as the following:

    mongo_wrapper_meta.c: In function ‘MongoConnect’:
    mongo_wrapper_meta.c:73:3: error: unknown type name ‘mongoc_ssl_opt_t’
       mongoc_ssl_opt_t *ssl_opts = (mongoc_ssl_opt_t*) malloc(sizeof(mongoc_ssl_opt_t));
       ^~~~~~~~~~~~~~~~

mongoc_ssl_opt_t is defined in mongoc-ssl.h, but it wasn't included because we didn't have libssl.