### PR TITLE
Fix referencing shared object error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,5 @@ RUN cd /tmp/fdw \
       && sed -i 's/D_POSIX_SOURCE/D_GNU_SOURCE/' mongo-c-driver/Makefile \
       && make \
       && make install \
-      && make clean
+      && make clean \
+      && ldconfig


### PR DESCRIPTION
Run ldconfig to update cache and fix the following error.

```
foo=# CREATE SERVER mongo_server11
foo-#          FOREIGN DATA WRAPPER mongo_fdw
foo-#          OPTIONS (address '192.168.0.5', port '30000', authentication_database 'admin');
ERROR:  could not load library "/usr/lib/postgresql/9.6/lib/mongo_fdw.so": libmongoc-1.0.so.0: cannot open shared object file: No such file or directory
```

ref: https://github.com/EnterpriseDB/mongo_fdw/issues/56